### PR TITLE
replace actool with nix + python builder

### DIFF
--- a/lib/mkACI.py
+++ b/lib/mkACI.py
@@ -1,0 +1,139 @@
+#!/usr/bin/env python
+import json
+import os
+from optparse import OptionParser
+from shutil import copyfile
+import subprocess
+import sys
+
+
+def parse_opts():
+    usage = "usage: %prog [options] file.aci manifest custom_env paths..."
+    parser = OptionParser(usage=usage)
+    parser.add_option("--thin", dest="thin")
+    parser.add_option("--dnsquirks", dest="dnsquirks")
+    parser.add_option("--static", dest="static")
+    (options, args) = parser.parse_args()
+    if len(args) < 3:
+        sys.stderr.write("not enough arguments")
+        parser.print_help()
+        sys.exit(1)
+    return options, args
+
+
+def paths_from_graphs(graphs):
+    paths = {}
+    for graph in graphs:
+        with open(graph) as f:
+            while True:
+                path = f.readline()
+                if not path:
+                    break
+                paths[path.rstrip()] = True
+                f.readline()
+                count = f.readline()
+                for i in range(int(count)):
+                    f.readline()
+    return paths.keys()
+
+
+def add_mounts(manifestPath, storePaths, mountArgPath):
+    with open(manifestPath) as f:
+        manifest = json.load(f)
+    with open(mountArgPath, "w+") as f:
+        mount_points = manifest["app"]["mountPoints"]
+        for path in storePaths:
+            name = path.replace(".", "").replace("/", "").lower()
+            mount_points.append({
+                'name': name,
+                'path': path,
+                'readOnly': True
+               })
+            args = "--volume=%s,kind=host,source=%s "
+            f.write(args % (name, path))
+    with open(manifestPath, "w") as f:
+        json.dump(manifest, f, indent=4)
+
+
+def tar(file_list, archive):
+    # prefix everything with rootfs except "manifest" and "rootfs" itself
+    t = ['flags=rSh',
+         's,^,rootfs/,',
+         's,^rootfs/manifest,manifest,',
+         's,^rootfs/rootfs,rootfs,']
+    cmd = ["tar",
+           "--create",
+           "--file", archive,
+           "--null",
+           "--gzip",
+           "-T", "-",
+           "--transform", ";".join(t)]
+    print("$ " + " ".join(cmd))
+    proc = subprocess.Popen(cmd, stdin=subprocess.PIPE)
+    proc.communicate(input=str.encode("\0".join(file_list)))
+
+
+def build_aci(aci,
+              manifest,
+              custom_env,
+              closures,
+              thin=True,
+              static=False,
+              dnsquirks=False):
+    os.mkdir(os.path.dirname(aci))
+    nixstore = []
+    envfiles = []
+    if static:
+        storePaths = [closures]
+    else:
+        storePaths = paths_from_graphs(closures)
+
+    for path in os.listdir(custom_env):
+        if path == "etc":
+            cp = ["cp", "-aL", os.path.join(custom_env, "etc"), "etc"]
+            subprocess.call(cp)
+        else:
+            envfiles.append(path)
+
+    copyfile(manifest, "manifest")
+    if thin:
+        mountArgPath = os.path.splitext(aci)[0] + ".mounts"
+        add_mounts("manifest", storePaths, mountArgPath)
+    else:
+        nixstore.append("-C/")
+        for path in storePaths:
+            nixstore.append(path.rstrip()[1:])
+
+    if dnsquirks:
+        if not os.path.exists("etc"):
+            os.mkdir("etc")
+        with open("etc/hosts", "w+") as f:
+            f.write("127.0.0.1 localhost\n::1 localhost\n")
+
+    os.mkdir("rootfs")
+    file_list = ["-C" + os.path.realpath("."), "manifest", "rootfs", "etc"]
+
+    file_list.append("-C/")
+    file_list += nixstore
+
+    file_list.append("-C" + custom_env)
+    file_list += envfiles
+
+    tar(file_list, aci)
+
+
+def main():
+    options, args = parse_opts()
+
+    def to_bool(s): return s in ["true"]
+
+    build_aci(args[0],
+              args[1],
+              args[2],
+              args[3:],
+              thin=to_bool(options.thin),
+              static=to_bool(options.static),
+              dnsquirks=to_bool(options.dnsquirks))
+
+if __name__ == "__main__":
+    main()

--- a/pkgs/linux/busybox-pfwd.nix
+++ b/pkgs/linux/busybox-pfwd.nix
@@ -27,11 +27,11 @@ mkACI rec {
   exec = ''/bin/busybox -- sh -c "busybox mkdir -p /sbin; /bin/busybox --install -s; sh"'';
 
   mountsRo = {
-    "rslvc"="/etc/resolv.conf";
+    rslvc = "/etc/resolv.conf";
   };
 
   ports = {
-    "nc" = [ "tcp" "1024" ];
+    nc = { protocol = "tcp"; port = "1024"; };
   };
 }
 

--- a/pkgs/linux/coreos-ipxe-server.nix
+++ b/pkgs/linux/coreos-ipxe-server.nix
@@ -31,10 +31,10 @@ in mkACI rec {
   acVersion = pkg.version;
 
   mounts = {
-    "datadir" = "/opt/coreos-ipxe-server";
+    datadir = "/opt/coreos-ipxe-server";
   };
 
   ports = {
-    "www" = [ "tcp" "4777" ];
+    www = { protocol = "tcp"; port = "4777"; };
   };
 }

--- a/pkgs/linux/dnsmasq.nix
+++ b/pkgs/linux/dnsmasq.nix
@@ -17,9 +17,9 @@ mkACI rec {
   exec = ''/bin/dnsmasq'';
 
   mounts = {
-    "varlibmisc" = "/var/lib/misc/";
-    "varrun" = "/var/run/";
-    "pxe" = "/pxe/";
+    varlibmisc = "/var/lib/misc/";
+    varrun = "/var/run/";
+    pxe = "/pxe/";
   };
 
   isolators = {

--- a/pkgs/linux/docker.nix
+++ b/pkgs/linux/docker.nix
@@ -11,7 +11,7 @@ mkACI rec {
   packages = [ pkg pkgs.busybox pkgs.cacert ];
 
   mounts = {
-    "libdocker"="/var/lib/docker";
-    "rundocker"="/var/run/docker";
+    libdocker = "/var/lib/docker";
+    rundocker = "/var/run/docker";
   };
 }

--- a/pkgs/linux/dovecot.nix
+++ b/pkgs/linux/dovecot.nix
@@ -1,5 +1,5 @@
 { mkACI, pkgs, thin ? false, ... } @ args:
-let 
+let
   pkg = pkgs.dovecot22;
 in
 
@@ -11,17 +11,17 @@ mkACI rec {
   packages = [ pkg pkgs.dovecot_pigeonhole ];
 
   ports = {
-      "imaps" = [ "tcp" "993" ];
-      "sieve" = [ "tcp" "4190" ];
+    imaps = { protocol = "tcp"; port = "993"; };
+    sieve = { protocol = "tcp"; port = "4190"; };
   };
 
   mounts = {
-    "mail" = "/var/vmail";
-    "etc-dovecot" = "/etc/dovecot";
+    mail = "/var/vmail";
+    etc-dovecot = "/etc/dovecot";
   };
 
   env = {
-      "LC_ALL" = "en_US.UTF-8";
-      "LANG" = "en_US.UTF-8";
+    LC_ALL = "en_US.UTF-8";
+    LANG = "en_US.UTF-8";
   };
 }

--- a/pkgs/linux/etcd2.nix
+++ b/pkgs/linux/etcd2.nix
@@ -1,5 +1,5 @@
 { mkACI, pkgs, thin ? false, ... } @ args:
-let 
+let
   pkg = pkgs.go15Packages.etcd.bin;
 in
 
@@ -14,14 +14,14 @@ mkACI rec {
   exec = "/bin/etcd";
 
   mounts = {
-    "datadir" = "/var/db/etcd2";
+    datadir = "/var/db/etcd2";
   };
 
   mountsRo = {
-    "resolvconf"="/etc/resolv.conf";
+    resolvconf = "/etc/resolv.conf";
   };
 
   env = {
-    "ETCD_DATA_DIR"="/var/db/etcd2/";
+    ETCD_DATA_DIR = "/var/db/etcd2/";
   };
 }

--- a/pkgs/linux/getmail.nix
+++ b/pkgs/linux/getmail.nix
@@ -1,5 +1,5 @@
 { mkACI, pkgs, thin ? false, ... } @ args:
-let 
+let
   pkg = pkgs.getmail;
 in
 
@@ -14,7 +14,7 @@ mkACI rec {
   group = "1000";
 
   env = {
-      "LC_ALL" = "en_US.UTF-8";
-      "LANG" = "en_US.UTF-8";
+    LC_ALL = "en_US.UTF-8";
+    LANG = "en_US.UTF-8";
   };
 }

--- a/pkgs/linux/plex.nix
+++ b/pkgs/linux/plex.nix
@@ -1,5 +1,5 @@
 { mkACI, pkgs, thin ? false, ... } @ args:
-let 
+let
   pkg = pkgs.plex;
 in
 
@@ -9,23 +9,23 @@ mkACI rec {
   packages = [ pkg ];
 
   mounts = {
-    "config" = "/var/lib/plexmediaserver/Library/Application Support";
-    "media" = "/media";
+    config = "/var/lib/plexmediaserver/Library/Application Support";
+    media = "/media";
   };
 
   ports = {
-      "https" = [ "tcp" "32400" ];
+    https = { protocol = "tcp"; port = "32400"; };
   };
 
   exec = "\"/usr/lib/plexmediaserver/Plex Media Server\"";
 
   env = {
-      "PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR" = "/var/lib/plexmediaserver/Library/Application Support";
-      "PLEX_MEDIA_SERVER_HOME" = "/usr/lib/plexmediaserver";
-      "PLEX_MEDIA_SERVER_MAX_PLUGIN_PROCS" = "6";
-      "PLEX_MEDIA_SERVER_TMPDIR" = "/tmp";
-      "LD_LIBRARY_PATH" = "/usr/lib/plexmediaserver";
-      "LC_ALL" = "en_US.UTF-8";
-      "LANG" = "en_US.UTF-8";
+    PLEX_MEDIA_SERVER_APPLICATION_SUPPORT_DIR = "/var/lib/plexmediaserver/Library/Application Support";
+    PLEX_MEDIA_SERVER_HOME = "/usr/lib/plexmediaserver";
+    PLEX_MEDIA_SERVER_MAX_PLUGIN_PROCS = "6";
+    PLEX_MEDIA_SERVER_TMPDIR = "/tmp";
+    LD_LIBRARY_PATH = "/usr/lib/plexmediaserver";
+    LC_ALL = "en_US.UTF-8";
+    LANG = "en_US.UTF-8";
   };
 }

--- a/pkgs/linux/qemu.nix
+++ b/pkgs/linux/qemu.nix
@@ -20,8 +20,8 @@ mkACI rec {
   '';
 
   ports = {
-    "spice" = [ "tcp" "5101" ];
-    "vnc" = [ "tcp" "5900" ];
+    spice = { protocol = "tcp"; port = "5101"; };
+    vnc = { protocol = "tcp"; port = "5900"; };
   };
 }
 

--- a/pkgs/linux/rkt.nix
+++ b/pkgs/linux/rkt.nix
@@ -1,5 +1,5 @@
 { mkACI, pkgs, thin ? false, ... } @ args:
-let 
+let
   pkg = pkgs.rkt;
 in
 


### PR DESCRIPTION
 By using nix, the manifest can be directly generated from nix expressions.
 When acbuild was used all dependencies had to be first copied into .acbuild
 before being compressed, the python script however build up a tar command,
 which creates the compressed archive in one shot. When building thin images,
 a shell script had to execute acbuild multiple times to add mounts. The python
 script however allows to update the json manifest without executing additional
 processes.

I was using python in the first place, because I assume it is often already installed and my original plan was to use the `tarfile` module to create an archive. However it turns out that creating tar files with python is way slower than using `tar` directly.
